### PR TITLE
Add quick enum creation.

### DIFF
--- a/electrode/core/enumbs.py
+++ b/electrode/core/enumbs.py
@@ -1,0 +1,15 @@
+"""
+enum Factory for electrode.
+"""
+
+from enum import Enum
+
+
+def CreateEnum(name: str, **kwargs):
+	"""
+	Creates an enum with spesified keys and values.
+
+	:param name: The name of the enum
+	:type name: str
+	"""
+	return Enum(name, kwargs)


### PR DESCRIPTION
This will allow for Electrode users to create simple, quick enumbs with out importing the enumb module itself.